### PR TITLE
GitHub Actions에서 Spring REST Docs 문서 생성 관련 에러 해결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build --debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+# WorkFlow for CI
+# Build & Test
+
+name: CI Test
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew clean build --debug
+        run: ./gradlew clean build --info

--- a/src/test/java/community/whatever/petcoming/feed/controller/CommunityFeedRestControllerTest.java
+++ b/src/test/java/community/whatever/petcoming/feed/controller/CommunityFeedRestControllerTest.java
@@ -89,6 +89,7 @@ class CommunityFeedRestControllerTest {
         list.add(response);
 
         BDDMockito.given(communityFeedService.getCommunityFeedInfoList(
+                        ArgumentMatchers.any(Long.class),
                         ArgumentMatchers.any(Integer.class),
                         ArgumentMatchers.any(FeedsSortOption.class)))
                 .willReturn(list);
@@ -97,7 +98,7 @@ class CommunityFeedRestControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.get(getCommunityInfoListUrl)
                         .param("last-feed", "1")
                         .param("size", "10")
-                        .param("sort", "LATEST")
+                        .param("sort", "POPULAR")
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andDo(

--- a/src/test/java/community/whatever/petcoming/feed/controller/CommunityFeedRestControllerTest.java
+++ b/src/test/java/community/whatever/petcoming/feed/controller/CommunityFeedRestControllerTest.java
@@ -34,7 +34,7 @@ class CommunityFeedRestControllerTest {
     private CommunityFeedService communityFeedService;
 
     private final String getCommunityInfoListUrl = "/api/v1/feed/community/";
-    private final String DOCUMENT_IDENTIFIER_PREFIX = "/CommunityFeed/";
+    private final String DOCUMENT_IDENTIFIER_PREFIX = "CommunityFeed/";
 
     @Test
     @DisplayName("댕글냥글 피드 목록 조회. 첫 조회")

--- a/src/test/java/community/whatever/petcoming/feed/controller/LostPetFeedRestControllerTest.java
+++ b/src/test/java/community/whatever/petcoming/feed/controller/LostPetFeedRestControllerTest.java
@@ -36,7 +36,7 @@ class LostPetFeedRestControllerTest {
     private LostPetFeedService lostPetFeedService;
 
     private final String getLostPetFeedInfoListUrl = "/api/v1/feed/lost-pet/";
-    private final String DOCUMENT_IDENTIFIER_PREFIX = "/LostPetFeed/";
+    private final String DOCUMENT_IDENTIFIER_PREFIX = "LostPetFeed/";
 
     @Test
     @DisplayName("찾아주세요 피드 목록 조회. 첫 조회")


### PR DESCRIPTION
Spring REST Docs 문서 생성 테스트 실패 문제 해결

현상:
Document 디렉토리 생성 실패로 테스트 실패
CommunityFeedRestControllerTest > 댕글냥글 피드 목록 조회. 재조회 FAILED
    java.lang.IllegalStateException: Failed to create directory '/CommunityFeed/목록_재조회'

원인:
document 경로 시작을 "/" 넣고 시작하면 실패함.

mockMvc.perform(MockMvcRequestBuilders.get("/url")
        )
        .andDo(MockMvcResultHandlers.print())
        .andDo(
                MockMvcRestDocumentation.document("/document경로",
                        Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                        Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
                )
        )
        .andExpect(MockMvcResultMatchers.status().isOk());

MockMvcRestDocumentation.document("/document경로",...) -> 실패
MockMvcRestDocumentation.document("document경로",...) -> 성공